### PR TITLE
Add workflow to build and release Android APK

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -3,9 +3,9 @@ name: android-apk
 on:
   workflow_dispatch:
   push:
-    branches: [ main ]
+    branches: [ master ]
   pull_request:
-    branches: [ main ]
+    branches: [ master ]
 
 jobs:
   build:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,57 @@
+name: android-apk
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+        with:
+          api-level: 33
+          ndk: 25.2.9519653
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-linux-android,armv7-linux-androideabi
+
+      - name: Install cargo-apk
+        run: cargo install cargo-apk
+
+      - name: Build release APK
+        run: cargo apk build --release -p xilem_example_mobile
+
+      - name: Locate APK
+        id: locate
+        run: echo "apk=$(find target -name '*.apk' -print -quit)" >> "$GITHUB_OUTPUT"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: xilem_example.apk
+          path: ${{ steps.locate.outputs.apk }}
+          compression-level: 0
+
+      - name: Publish release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: apk-${{ github.run_number }}
+          name: Android build ${{ github.run_number }}
+          draft: false
+          prerelease: true
+          files: ${{ steps.locate.outputs.apk }}
+

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch:
   push:
     branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
 jobs:
   build:
@@ -35,18 +37,23 @@ jobs:
       - name: Build release APK
         run: cargo apk build --release -p xilem_example_mobile
 
-      - name: Locate APK
+      - name: Locate and rename APK
         id: locate
-        run: echo "apk=$(find target -name '*.apk' -print -quit)" >> "$GITHUB_OUTPUT"
+        run: |
+          apk=$(find target -name '*.apk' -print -quit)
+          name="xilem_example-${{ github.run_number }}.apk"
+          cp "$apk" "$name"
+          echo "apk=$name" >> "$GITHUB_OUTPUT"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: xilem_example.apk
+          name: xilem_example-${{ github.run_number }}.apk
           path: ${{ steps.locate.outputs.apk }}
           compression-level: 0
 
       - name: Publish release
+        if: github.event_name != 'pull_request'
         uses: softprops/action-gh-release@v1
         with:
           tag_name: apk-${{ github.run_number }}

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           api-level: 33
           ndk: 25.2.9519653
+          components: "platforms;android-31"
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -12,23 +12,23 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4
         with:
           distribution: temurin
           java-version: '17'
 
       - name: Set up Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
         with:
           api-level: 33
           ndk: 25.2.9519653
           components: "platforms;android-31"
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4305c38b25d97ef35a8ad1f985ccf2d2242004f2 # stable
         with:
           targets: aarch64-linux-android,armv7-linux-androideabi
 
@@ -47,7 +47,7 @@ jobs:
           echo "apk=$name" >> "$GITHUB_OUTPUT"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: xilem_example-${{ github.run_number }}.apk
           path: ${{ steps.locate.outputs.apk }}
@@ -55,7 +55,7 @@ jobs:
 
       - name: Publish release
         if: github.event_name != 'pull_request'
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
         with:
           tag_name: apk-${{ github.run_number }}
           name: Android build ${{ github.run_number }}


### PR DESCRIPTION
## Summary
- build release APK for Android using cargo-apk
- upload uncompressed artifact and publish release for direct download

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68a4214bd17883208557bc4b490a7de5