### PR TITLE
docs: add AGENTS instructions for codex workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+# AGENTS
+
+## General Workflow
+- Before starting work or amending commits, ensure your branch is up to date with `master` to avoid merge conflicts when multiple PRs are in flight:
+  - `git fetch origin`
+  - `git rebase origin/master` (or `git merge origin/master` if you prefer)
+- Format code with `cargo fmt --all`.
+- Run `cargo clippy --all-targets --all-features -- -D warnings`.
+- Run the test suite with `cargo test`.
+
+## Pull Request Guidelines
+- Use descriptive commit messages and PR titles.
+- Keep commits focused and small when possible.


### PR DESCRIPTION
## Summary
- add repository guidelines for AI contributors in AGENTS.md

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a4274630148320aaee0422b57b6cc2